### PR TITLE
Fixing 2 errors in Unlock-PveVm and 1 in Invoke-PveRestApi

### DIFF
--- a/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
+++ b/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
@@ -726,8 +726,8 @@ PveResponse. Return response.
 
     process {
         $vm = Get-PveVm -PveTicket $PveTicket -VmIdOrName $VmIdOrName
-        if ($vm.type -eq 'qemu') { return $vm | Set-PveNodesQemuConfig -PveTicket $PveTicket -Delete 'lock' -Skiplock }
-        ElseIf ($vm.type -eq 'lxc') { return $vm | Set-PveNodesLxcConfig -PveTicket $PveTicket -Delete 'lock' }
+        if ($vm.type -eq 'qemu') { return Set-PveNodesQemuConfig -PveTicket $PveTicket -node $vm.node -Vmid $vm.vmid -Delete 'lock' -Skiplock:$true }
+        ElseIf ($vm.type -eq 'lxc') { return Set-PveNodesLxcConfig -PveTicket $PveTicket -node $vm.node -Vmid $vm.vmid -Delete 'lock' }
     }
 }
 
@@ -32858,4 +32858,5 @@ PveResponse. Return response.
         return Invoke-PveRestApi -PveTicket $PveTicket -Method Get -Resource "/version"
     }
 }
+
 


### PR DESCRIPTION
Fixing 2 errors in Unlock-PveVm see Issue #45 

Fixing error in Invoke-PveRestApi: no catching of possible empty $Global:PveTicketLast when no Connect-PveCluster is called before. see Issue #47 