### PR TITLE
Fix version to 9.1.2 and rename release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
           Write-Host "Version validated: $moduleVersion"
           echo "version=$moduleVersion" >> $env:GITHUB_OUTPUT
 
+      - name: Publish module to PowerShell Gallery
+        shell: pwsh
+        env:
+          PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+        run: |
+          Publish-Module -Path ./Corsinvest.ProxmoxVE.Api -NuGetApiKey $env:PSGALLERY_API_KEY -Verbose
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -56,10 +63,3 @@ jobs:
           name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-
-      - name: Publish module to PowerShell Gallery
-        shell: pwsh
-        env:
-          PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
-        run: |
-          Publish-Module -Path ./Corsinvest.ProxmoxVE.Api -NuGetApiKey $env:PSGALLERY_API_KEY -Verbose

--- a/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psd1
+++ b/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Corsinvest.ProxmoxVE.Api.psm1'
 
 # Version number of this module.
-ModuleVersion = '9.1.3'
+ModuleVersion = '9.1.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
## Summary
- Fix module version from 9.1.3 to 9.1.2 (last published release was v9.1.1)
- Rename workflow from `publish-psgallery.yml` to `release.yml`
- Fix workflow step order: publish to PowerShell Gallery before creating GitHub Release