### PR TITLE
Fix bool parameters serialization in Invoke-PveRestApi

### DIFF
--- a/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
+++ b/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
@@ -273,7 +273,7 @@ Return object request
         if ($Parameters -and $Parameters.Count -gt 0 )
         {
              $Parameters.keys | ForEach-Object {
-                $parametersTmp[$_] = $Parameters[$_] -is [switch] `
+                $parametersTmp[$_] = ($Parameters[$_] -is [switch] -or $Parameters[$_] -is [bool]) `
                                          ? $Parameters[$_] ? 1 : 0 `
                                          : $Parameters[$_]
              }


### PR DESCRIPTION
## Summary

- Fixes #57 (and the same root cause as #41)
- `[bool]` parameters were sent to Proxmox API as `True`/`False` strings, causing HTTP 400 `Parameter verification failed`
- Extended the existing `[switch]` → `1`/`0` conversion in `Invoke-PveRestApi` to also handle `[bool]` parameters

## Root cause

The generator maps Proxmox API boolean fields to PowerShell `[bool]` (changed from `[switch]` in #36 to allow passing `$false`). However, the serialization in `Invoke-PveRestApi` only converted `[switch]` to `1`/`0`, leaving `[bool]` as-is (`True`/`False`), which Proxmox rejects.

## Test plan

- [ ] `Remove-PveNodesLxc -Node <node> -Vmid <id> -Purge $true` returns success instead of HTTP 400
- [ ] `Remove-PveNodesQemu -Node <node> -Vmid <id> -Purge $true -DestroyUnreferencedDisks $true` returns success
- [ ] Passing `$false` for a bool parameter still works correctly (sends `0`)